### PR TITLE
Feature/1854,1855 cpp compatible,mcu build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,6 @@ endif()
 #
 #   Virgil IoT SDK
 #
-set(VIRGIL_IOT_MCU_BUILD OFF CACHE BOOL "Turn off MCU build" FORCE)
 set(VIRGIL_IOT_CONFIG_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/ext/virgil-iot-sdk/config/pc CACHE STRING "Path to the Virgil IoT SDK configuration")
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/ext/virgil-iot-sdk)
 

--- a/common/include/sdk-impl/netif/netif-queue.h
+++ b/common/include/sdk-impl/netif/netif-queue.h
@@ -39,6 +39,6 @@
 #include <virgil/iot/protocols/snap/snap-structs.h>
 
 vs_netif_t *
-vs_netif_queued(const vs_netif_t *base_netif);
+vs_netif_queued(vs_netif_t *base_netif);
 
 #endif // VS_IOT_NETIF_QUEUE_IMPL_H

--- a/common/src/sdk-impl/netif/netif-queue.c
+++ b/common/src/sdk-impl/netif/netif-queue.c
@@ -43,7 +43,7 @@
 
 #define VS_NETIF_QUEUE_SZ (100)
 
-static const vs_netif_t *_base_netif = 0;
+static vs_netif_t *_base_netif = 0;
 static vs_netif_process_cb_t _netif_process_cb = 0;
 static vs_netif_t _queued_netif = {0};
 static vs_msg_queue_ctx_t *_queue_ctx = 0;
@@ -111,7 +111,9 @@ _periodical_processing(void *ctx) {
 
 /******************************************************************************/
 static vs_status_e
-_init_with_queue(const vs_netif_rx_cb_t netif_rx_cb, const vs_netif_process_cb_t netif_process_cb) {
+_init_with_queue(struct vs_netif_t *netif,
+                 const vs_netif_rx_cb_t netif_rx_cb,
+                 const vs_netif_process_cb_t netif_process_cb) {
     assert(_base_netif);
     CHECK_RET(_base_netif, -1, "Unable to initialize queued Netif because of wrong Base Netif");
 
@@ -130,22 +132,22 @@ _init_with_queue(const vs_netif_rx_cb_t netif_rx_cb, const vs_netif_process_cb_t
     // Create thread to call Callbacks on data receive
     if (0 == pthread_create(&_queue_thread, NULL, _msg_processing, NULL)) {
         _queue_thread_ready = true;
-        return _base_netif->init(netif_rx_cb, _queue_and_process);
+        return _base_netif->init(_base_netif, netif_rx_cb, _queue_and_process);
     }
 
     VS_LOG_ERROR("Cannot start thread to process RX Queue");
-    _queued_netif.deinit();
+    _queued_netif.deinit(&_queued_netif);
 
     return VS_CODE_ERR_THREAD;
 }
 
 /******************************************************************************/
 static vs_status_e
-_deinit_with_queue() {
+_deinit_with_queue(struct vs_netif_t *netif) {
     vs_status_e res;
 
     // Stop base Network Interface
-    res = _base_netif->deinit();
+    res = _base_netif->deinit(_base_netif);
 
     // Stop RX processing thread
     if (_queue_thread_ready) {
@@ -174,7 +176,7 @@ _deinit_with_queue() {
 
 /******************************************************************************/
 vs_netif_t *
-vs_netif_queued(const vs_netif_t *base_netif) {
+vs_netif_queued(vs_netif_t *base_netif) {
     assert(base_netif);
     CHECK_RET(base_netif, NULL, "Unable to initialize queued Netif because of wrong Base Netif");
     _base_netif = base_netif;

--- a/common/src/sdk-impl/netif/netif-udp-broadcast.c
+++ b/common/src/sdk-impl/netif/netif-udp-broadcast.c
@@ -46,16 +46,16 @@
 #include <virgil/iot/logger/logger.h>
 
 static vs_status_e
-_udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
+_udp_bcast_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
 
 static vs_status_e
-_udp_bcast_deinit();
+_udp_bcast_deinit(struct vs_netif_t *netif);
 
 static vs_status_e
-_udp_bcast_tx(const uint8_t *data, const uint16_t data_sz);
+_udp_bcast_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz);
 
 static vs_status_e
-_udp_bcast_mac(struct vs_mac_addr_t *mac_addr);
+_udp_bcast_mac(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr);
 
 static vs_netif_t _netif_udp_bcast = {.user_data = NULL,
                                       .init = _udp_bcast_init,
@@ -174,14 +174,14 @@ _udp_bcast_connect() {
 
 terminate:
 
-    _udp_bcast_deinit();
+    _udp_bcast_deinit(&_netif_udp_bcast);
 
     return VS_CODE_ERR_SOCKET;
 }
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_tx(const uint8_t *data, const uint16_t data_sz) {
+_udp_bcast_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz) {
     struct sockaddr_in broadcast_addr;
 
     memset((void *)&broadcast_addr, 0, sizeof(struct sockaddr_in));
@@ -196,7 +196,7 @@ _udp_bcast_tx(const uint8_t *data, const uint16_t data_sz) {
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
+_udp_bcast_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
     assert(rx_cb);
     _netif_udp_bcast_rx_cb = rx_cb;
     _netif_udp_bcast_process_cb = process_cb;
@@ -208,7 +208,7 @@ _udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t proces
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_deinit() {
+_udp_bcast_deinit(struct vs_netif_t *netif) {
     if (_udp_bcast_sock >= 0) {
 #if !defined(__APPLE__)
         shutdown(_udp_bcast_sock, SHUT_RDWR);
@@ -222,7 +222,7 @@ _udp_bcast_deinit() {
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_mac(struct vs_mac_addr_t *mac_addr) {
+_udp_bcast_mac(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr) {
 
     if (mac_addr) {
         memcpy(mac_addr->bytes, _sim_mac_addr, sizeof(vs_mac_addr_t));

--- a/gateway/src/main.c
+++ b/gateway/src/main.c
@@ -74,8 +74,8 @@ _add_filetype(const vs_update_file_type_t *file_type, vs_update_interface_t **up
 int
 main(int argc, char *argv[]) {
     vs_mac_addr_t forced_mac_addr;
-    const vs_snap_service_t *snap_info_server;
-    const vs_snap_service_t *snap_fldt_server;
+    vs_snap_service_t *snap_info_server;
+    vs_snap_service_t *snap_fldt_server;
     int res = -1;
 
     // Implementation variables

--- a/initializer/src/main.c
+++ b/initializer/src/main.c
@@ -48,7 +48,7 @@
 int
 main(int argc, char *argv[]) {
     vs_mac_addr_t forced_mac_addr;
-    const vs_snap_service_t *snap_prvs_server;
+    vs_snap_service_t *snap_prvs_server;
     vs_status_e ret_code;
 
     // Implementation variables

--- a/thing/src/main.c
+++ b/thing/src/main.c
@@ -64,8 +64,8 @@ _on_file_updated(vs_update_file_type_t *file_type,
 int
 main(int argc, char *argv[]) {
     vs_mac_addr_t forced_mac_addr;
-    const vs_snap_service_t *snap_info_server;
-    const vs_snap_service_t *snap_fldt_client;
+    vs_snap_service_t *snap_info_server;
+    vs_snap_service_t *snap_fldt_client;
     int res = -1;
 
     // Implementation variables


### PR DESCRIPTION
- Set VIRGIL_IOT_MCU_BUILD by default to OFF
- Enclose all headers to `namespace VirgilIoTKit { extern "C" { ... } }`
- Fix `_snap_fill_header` declaration
- Add context for C++ class compatibility, fix some return ones
- Rename `vs_snap_info_callbacks_t` to `vs_snap_info_client_service_t`
- Documentation fixes
- "Green" [IKIT-integration-test #665](https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-integration-test/665/)
- "Yellow" because of PVS license [IKIT-tests #382](https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-tests/382/)