### PR TITLE
Use mbedtls into the secmodule default implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ To start working with the IoTKit Demo you have to:
 ```shell
 $ git clone --recursive https://github.com/VirgilSecurity/virgil-iotkit
 ```
-- Install Virgil Crypto library from IoTKit scripts folder by running the script:
-```shell
-$ scripts/install-virgil-crypto.sh
-```
-
 ## Run Tests
 To make sure that everything goes in the right way, we also provide a set of ready code-snippets for testing the necessary features:
 - Crypto: crypto algorithms (e. g. hash, RNG, AES) and crypto operations (key pair, sign/verify etc.).

--- a/gateway/CMakeLists.txt
+++ b/gateway/CMakeLists.txt
@@ -117,7 +117,7 @@ target_link_libraries(gateway
 #
 if(NOT GO_DISABLE)
 	if(NOT GW_APP_FILE_SIZE)
-		set(GW_APP_FILE_SIZE "1048576" CACHE STRING "Full gateway application file size")
+		set(GW_APP_FILE_SIZE "2097152" CACHE STRING "Full gateway application file size")
 	endif()
 
 	if(NOT GW_APP_CHUNK_SIZE)

--- a/tests/main.c
+++ b/tests/main.c
@@ -42,7 +42,6 @@
 #include <virgil/iot/secbox/secbox.h>
 #include <virgil/iot/storage_hal/storage_hal.h>
 #include <virgil/iot/trust_list/trust_list.h>
-#include <virgil/crypto/foundation/vscf_assert.h>
 #include <virgil/iot/vs-soft-secmodule/vs-soft-secmodule.h>
 #include <virgil/iot/firmware/firmware.h>
 #include <update-config.h>
@@ -126,12 +125,6 @@ _remove_keystorage_dir() {
 }
 
 /********************************************************************************/
-static void
-_assert_handler_fn(const char *message, const char *file, int line) {
-    VS_LOG_ERROR("%s %s %u", message, file, line);
-}
-
-/********************************************************************************/
 int
 main(int argc, char *argv[]) {
     int res = -1;
@@ -155,7 +148,6 @@ main(int argc, char *argv[]) {
     vs_app_str_to_bytes(device_type, TEST_DEVICE_TYPE, sizeof(device_type));
 
     vs_logger_init(VS_LOGLEV_DEBUG);
-    vscf_assert_change_handler(_assert_handler_fn);
 
     // Set self path
     vs_firmware_nix_set_info(argv[0], manufacture_id, device_type);

--- a/thing/CMakeLists.txt
+++ b/thing/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(thing
 #
 if(NOT GO_DISABLE)
 	if(NOT THING_APP_FILE_SIZE)
-		set(THING_APP_FILE_SIZE "1048576" CACHE STRING "Full thing application file size")
+		set(THING_APP_FILE_SIZE "2097152" CACHE STRING "Full thing application file size")
 	endif()
 
 	if(NOT THING_APP_CHUNK_SIZE)


### PR DESCRIPTION
It's related to https://github.com/VirgilSecurity/virgil-iotkit/pull/181

Test results
https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-integration-test/692/
https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-tests/413/